### PR TITLE
Remove link errors

### DIFF
--- a/LBM/Makefile
+++ b/LBM/Makefile
@@ -149,7 +149,7 @@ $(program): $(source) Makefile
 	$(CC) $(CFLAGS) args.c lbm.cu lbm_kernel.cu parboil_cuda.c main.cc $(LDFLAGS) -o $@
 
 clean:
-	rm -rf $(program) *.o *.re_export
+	rm -f args.c.re_export lbm lbm.cu.re_export lbm_kernel.cu.re_export main.cc.re_export out.txt parboil_cuda.c.re_export 
 
 run: $(program)
 	./$(program) 10 -o out.txt

--- a/LBM/Makefile
+++ b/LBM/Makefile
@@ -38,7 +38,8 @@ SM_VERSION  = 120
 
 program = lbm
 
-source = args.c lbm.cu lbm_kernel.cu parboil_cuda.c main.cc
+# lbm_kernel.cu
+source = args.c lbm.cu parboil_cuda.c main.cc
 
 #===============================================================================
 # Sets Flags
@@ -53,11 +54,25 @@ CFLAGS := -mllvm -max-heap-to-stack-size=1000000 -I $(CUDA_PATH)/include -I .
 CC := $(CLANG_PATH)
 
 ENZYME_LOAD_FLAGS :=
+REACTANT_PLUGIN_FLAGS :=
+
 ifeq ($(EMBEDDED_CLANG),no)
   ENZYME_LOAD_FLAGS += -fplugin=$(ENZYME_PATH)
+  REACTANT_PLUGIN_FLAGS += -fplugin-arg-enzyme-raising-plugin-path=$(LIB_RAISE_PATH)
+  REACTANT_PLUGIN_FLAGS += -fplugin-arg-enzyme-reactant-backend=cuda
+else
+  #reactant-clang
+  REACTANT_PLUGIN_FLAGS += -Xclang -add-plugin -Xclang enzyme
+  REACTANT_PLUGIN_FLAGS += -mllvm -reactant-backend -mllvm cuda
 endif
 
-CFLAGS += -ffast-math --cuda-path=$(CUDA_PATH) -L$(CUDA_PATH)/lib64 --cuda-gpu-arch=sm_$(SM_VERSION)  -std=c++11 $(ENZYME_LOAD_FLAGS) -Xclang -add-plugin -Xclang enzyme -mllvm -raising-plugin-path -mllvm $(LIB_RAISE_PATH) -mllvm -reactant-backend -mllvm cuda -x cuda -fno-exceptions
+CFLAGS += -ffast-math                       \
+          --cuda-path=$(CUDA_PATH)          \
+          -L$(CUDA_PATH)/lib64              \
+          --cuda-gpu-arch=sm_$(SM_VERSION)  \
+          -std=c++11                        \
+          $(ENZYME_LOAD_FLAGS) $(REACTANT_PLUGIN_FLAGS) \
+          -x cuda -fno-exceptions
   
 
 # Linker Flags
@@ -144,9 +159,9 @@ endif
 #===============================================================================
 # Targets to Build
 #===============================================================================
-
+# lbm_kernel.cu
 $(program): $(source) Makefile
-	$(CC) $(CFLAGS) args.c lbm.cu lbm_kernel.cu parboil_cuda.c main.cc $(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) args.c lbm.cu parboil_cuda.c main.cc $(LDFLAGS) -o $@
 
 clean:
 	rm -f args.c.re_export lbm lbm.cu.re_export lbm_kernel.cu.re_export main.cc.re_export out.txt parboil_cuda.c.re_export 


### PR DESCRIPTION
Bazel plugin builds for reactant error out if we include lbm_kernel.cu during link, seems like a duplicate symbol bug in the code itself. 