### PR TITLE
LULESH guard software atomicAdd<double> for CUDA 12+ toolchains

### DIFF
--- a/LULESH/util.h
+++ b/LULESH/util.h
@@ -58,7 +58,8 @@ void printVector(const char* label, const vector &v)
   std::cout  << std::endl;
 }
 
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 600 
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 600 && \
+    (!defined(__CUDACC_VER_MAJOR__) || __CUDACC_VER_MAJOR__ < 12) 
 // Double precision atomicAdd in software
 static 
 __device__ 


### PR DESCRIPTION
CUDA 12 unconditionally provides `atomicAdd(double*, double)` for all `__CUDA_ARCH__ levels`, so try to update `util.h` for only manaully provide `atomicAdd(double*, double)` when building for `sm < 60` with a CUDA 12+ toolchain